### PR TITLE
feat: add --prune flag to guardian:sync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,9 @@ php artisan guardian:sync --panel=admin --panel=app
 
 # Verbose output to see each permission being created
 php artisan guardian:sync -v
+
+# Prune stale permissions no longer in the discovery set
+php artisan guardian:sync --prune
 ```
 
 | Type | Permissions created |
@@ -578,6 +581,14 @@ php artisan guardian:sync -v
 | Pages | `Access:Dashboard`, `Access:Settings`, etc. |
 | Widgets | `View:StatsOverview`, `View:RevenueChart`, etc. |
 | Custom | Whatever you define in `config/filament-guardian.php` |
+
+#### Pruning stale permissions
+
+By default, `guardian:sync` only creates new permissions and never deletes existing ones. Use `--prune` to remove permissions that are no longer part of the discovery set — for example, when a resource is deleted, a page is removed, or custom permissions are taken out of the config.
+
+When pruning, the command first syncs all expected permissions, then deletes any database permission for the synced guards that isn't in the expected set. Before deletion, each stale permission is detached from all roles and users to avoid orphaned pivot records.
+
+> **Warning:** Pruning is destructive. Once a permission is deleted, it cannot be recovered. Roles and users will lose assignments to pruned permissions. Use `--prune` only when you're certain the removed permissions should no longer exist.
 
 Example zero-downtime deployment:
 

--- a/src/Commands/Concerns/CreatesPermissions.php
+++ b/src/Commands/Concerns/CreatesPermissions.php
@@ -100,4 +100,35 @@ trait CreatesPermissions
     {
         return app(PermissionKeyBuilder::class);
     }
+
+    /**
+     * Delete permissions for a guard that are not in the expected set.
+     *
+     * @param  array<int, string>  $expectedKeys
+     */
+    protected function pruneStalePermissionsForGuard(string $guard, array $expectedKeys): int
+    {
+        if ($expectedKeys === []) {
+            return 0;
+        }
+
+        $permissionModel = $this->getPermissionModel();
+
+        $stalePermissions = $permissionModel::query()
+            ->whereRaw('guard_name = ?', [$guard])
+            ->whereNotIn('name', $expectedKeys)
+            ->get();
+
+        $deleted = 0;
+
+        foreach ($stalePermissions as $permission) {
+            /** @var Permission $permission */
+            $permission->roles()->detach();
+            $permission->users()->detach();
+            $permission->delete();
+            $deleted++;
+        }
+
+        return $deleted;
+    }
 }

--- a/src/Commands/SyncPermissionsCommand.php
+++ b/src/Commands/SyncPermissionsCommand.php
@@ -20,13 +20,17 @@ class SyncPermissionsCommand extends Command
     /** @var string */
     public $signature = 'guardian:sync
         {--panel=* : Specific panel IDs to sync (syncs all if not specified)}
-        {--no-relation-managers : Skip auto-discovered relation managers}';
+        {--no-relation-managers : Skip auto-discovered relation managers}
+        {--prune : Delete permissions no longer in the discovery set}';
 
     /** @var string */
     public $description = 'Sync permissions for all Filament panels';
 
-    /** @var array<string, array{created: int, existing: int}> */
+    /** @var array<string, array{created: int, existing: int, deleted: int}> */
     protected array $stats = [];
+
+    /** @var array<string, array<int, string>> */
+    protected array $expectedPermissions = [];
 
     public function handle(): int
     {
@@ -46,6 +50,11 @@ class SyncPermissionsCommand extends Command
         }
 
         $this->syncCustomPermissions($panels);
+
+        if ($this->option('prune')) {
+            $this->pruneStalePermissions();
+        }
+
         $this->displaySummary();
 
         return self::SUCCESS;
@@ -85,7 +94,8 @@ class SyncPermissionsCommand extends Command
 
         $this->validateGuard($guard);
 
-        $this->stats[$guard] ??= ['created' => 0, 'existing' => 0];
+        $this->stats[$guard] ??= ['created' => 0, 'existing' => 0, 'deleted' => 0];
+        $this->expectedPermissions[$guard] ??= [];
 
         $this->syncResources($panel, $guard);
         $this->syncRelationManagers($panel, $guard);
@@ -111,6 +121,7 @@ class SyncPermissionsCommand extends Command
             foreach ($permissionKeys as $key) {
                 $result = $this->createPermission($key, $guard);
                 $this->recordStat($guard, $result['created']);
+                $this->expectedPermissions[$guard][] = $key;
 
                 if ($this->output->isVerbose()) {
                     $status = $result['created'] ? '<fg=green>Created</>' : '<fg=gray>Exists</>';
@@ -149,6 +160,7 @@ class SyncPermissionsCommand extends Command
             foreach ($permissionKeys as $key) {
                 $result = $this->createPermission($key, $guard);
                 $this->recordStat($guard, $result['created']);
+                $this->expectedPermissions[$guard][] = $key;
                 $totalPermissions++;
 
                 if ($this->output->isVerbose()) {
@@ -179,6 +191,7 @@ class SyncPermissionsCommand extends Command
             $key = $this->buildPagePermissionKey($prefix, $subject);
             $result = $this->createPermission($key, $guard);
             $this->recordStat($guard, $result['created']);
+            $this->expectedPermissions[$guard][] = $key;
 
             if ($this->output->isVerbose()) {
                 $status = $result['created'] ? '<fg=green>Created</>' : '<fg=gray>Exists</>';
@@ -207,6 +220,7 @@ class SyncPermissionsCommand extends Command
             $key = $this->buildWidgetPermissionKey($prefix, $subject);
             $result = $this->createPermission($key, $guard);
             $this->recordStat($guard, $result['created']);
+            $this->expectedPermissions[$guard][] = $key;
 
             if ($this->output->isVerbose()) {
                 $status = $result['created'] ? '<fg=green>Created</>' : '<fg=gray>Exists</>';
@@ -246,6 +260,7 @@ class SyncPermissionsCommand extends Command
             foreach ($guards as $guard) {
                 $result = $this->createPermission($key, $guard);
                 $this->recordStat($guard, $result['created']);
+                $this->expectedPermissions[$guard][] = $key;
 
                 if ($this->output->isVerbose()) {
                     $status = $result['created'] ? '<fg=green>Created</>' : '<fg=gray>Exists</>';
@@ -278,27 +293,58 @@ class SyncPermissionsCommand extends Command
         }
     }
 
+    protected function pruneStalePermissions(): void
+    {
+        $guards = array_keys($this->stats);
+
+        if ($guards === []) {
+            return;
+        }
+
+        $this->components->warn('Pruning stale permissions from ' . count($guards) . ' guard(s)...');
+        $this->newLine();
+
+        foreach ($guards as $guard) {
+            $expected = array_values(array_unique($this->expectedPermissions[$guard] ?? []));
+            $deleted = $this->pruneStalePermissionsForGuard($guard, $expected);
+
+            if ($deleted > 0) {
+                $this->stats[$guard]['deleted'] += $deleted;
+                $this->components->twoColumnDetail(
+                    "Guard: {$guard}",
+                    "<fg=red>{$deleted} deleted</>"
+                );
+            }
+        }
+
+        $this->newLine();
+    }
+
     protected function displaySummary(): void
     {
         $this->components->info('Summary');
 
         $totalCreated = 0;
         $totalExisting = 0;
+        $totalDeleted = 0;
 
         foreach ($this->stats as $guard => $counts) {
             $totalCreated += $counts['created'];
             $totalExisting += $counts['existing'];
+            $totalDeleted += $counts['deleted'];
 
             $this->components->twoColumnDetail(
                 "Guard: {$guard}",
-                "<fg=green>{$counts['created']} created</>, <fg=gray>{$counts['existing']} existing</>"
+                "<fg=green>{$counts['created']} created</>, <fg=gray>{$counts['existing']} existing</>" .
+                ($counts['deleted'] > 0 ? ", <fg=red>{$counts['deleted']} deleted</>" : '')
             );
         }
 
         $this->newLine();
         $this->components->twoColumnDetail(
             '<fg=bright-white>Total</>',
-            "<fg=green>{$totalCreated} created</>, <fg=gray>{$totalExisting} existing</>"
+            "<fg=green>{$totalCreated} created</>, <fg=gray>{$totalExisting} existing</>" .
+            ($totalDeleted > 0 ? ", <fg=red>{$totalDeleted} deleted</>" : '')
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional `--prune` flag to the `guardian:sync` command that deletes permissions no longer in the discovery set after sync completes.

## Problem

When resources, pages, widgets are removed or custom permissions are taken out of the config, the old permissions remain in the database because `sync` only creates, never deletes. ([#4](https://github.com/Waguilar33/filament-guardian/issues/4))

## Changes

- **`src/Commands/SyncPermissionsCommand.php`**
  - Added `{--prune}` flag to signature
  - Added `$expectedPermissions` tracking — accumulates expected permission keys per guard across all sync methods (resources, relation managers, pages, widgets, custom)
  - New `pruneStalePermissions()` runs after sync when `--prune` is set
  - Summary output now includes `deleted` count per guard and in totals

- **`src/Commands/Concerns/CreatesPermissions.php`**
  - Added `pruneStalePermissionsForGuard()` — queries stale permissions for a guard, detaches from roles/users, then deletes each one

- **`README.md`**
  - Documented `--prune` flag with usage example and warning about destructive behavior

## Usage

```bash
# Normal sync (create-only, unchanged behavior)
php artisan guardian:sync

# Sync + delete stale permissions
php artisan guardian:sync --prune

# Scoped to specific panel
php artisan guardian:sync --panel=admin --prune
```

## Design Decisions

- **Opt-in only** — `--prune` is optional; default sync behavior is unchanged
- **Guard-aware** — multiple panels sharing a guard merge their expected keys; only truly orphaned permissions are deleted
- **Pivot cleanup** — stale permissions are detached from roles and users before deletion to avoid orphaned pivot records
- **No confirmation prompt** — the flag name self-documents destructive intent, suitable for CI/CD pipelines